### PR TITLE
Fix php 8.2 deprecation error in logs

### DIFF
--- a/src/InstagramFeed.php
+++ b/src/InstagramFeed.php
@@ -39,12 +39,12 @@ class InstagramFeed implements IteratorAggregate, Countable
         }
     }
 
-    public function getIterator()
+    public function getIterator() : ArrayIterator
     {
         return new ArrayIterator($this->items);
     }
 
-    public function count()
+    public function count() : Int
     {
         return count($this->items);
     }


### PR DESCRIPTION
Fix php 8.2 deprecation error by adding type declaration to getIteratior() and count() functions.